### PR TITLE
Fix crash when no window in AppDelegate

### DIFF
--- a/KNPhotoBrowser/KNPhotoBrowser/KNPhotoBrowserPch.h
+++ b/KNPhotoBrowser/KNPhotoBrowser/KNPhotoBrowserPch.h
@@ -24,7 +24,7 @@
 ({\
     BOOL hasBang = false;\
     if (@available(iOS 11.0, *)) {\
-        hasBang = [UIApplication sharedApplication].delegate.window.safeAreaInsets.bottom;\
+        hasBang = [UIApplication sharedApplication].keyWindow.safeAreaInsets.bottom;\
     }\
     (hasBang);\
 })


### PR DESCRIPTION
当AppDelegate中没有window属性的时候会闪退。

```
 *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[XXX.AppDelegate window]: unrecognized selector sent to instance 0x600000878320'
```

不过keyWindow也不是一个最好的方案，多窗口不知道是否会有问题。如果要window可以让用户在初始化的时候往里面传。这样的话SwiftUI也能用。